### PR TITLE
Add Secret Manager rotation check

### DIFF
--- a/exports.js
+++ b/exports.js
@@ -1542,6 +1542,7 @@ module.exports = {
         'apiKeyActiveServices'          : require(__dirname + '/plugins/google/api/apiKeyActiveServices.js'),
         'projectAPIKeys'                : require(__dirname + '/plugins/google/api/projectAPIKeys.js'),
         'apiKeyAPIRestriction'          : require(__dirname + '/plugins/google/api/apiKeyAPIRestriction.js'),
+        'secretRotation'               : require(__dirname + '/plugins/google/secretmanager/secretRotation.js'),
 
         'privateEndpoint'               : require(__dirname + '/plugins/google/kubernetes/privateEndpoint.js'),
         'monitoringEnabled'             : require(__dirname + '/plugins/google/kubernetes/monitoringEnabled.js'),

--- a/plugins/google/secretmanager/secretRotation.js
+++ b/plugins/google/secretmanager/secretRotation.js
@@ -1,0 +1,77 @@
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Secret Rotation',
+    category: 'Secret Manager',
+    domain: 'Identity and Access Management',
+    severity: 'Medium',
+    description: 'Ensure secrets have rotation schedules or expire in a timely manner.',
+    more_info: 'Secrets without rotation or expiration may remain valid indefinitely and increase risk of compromise.',
+    link: 'https://cloud.google.com/secret-manager/docs/secret-rotation',
+    recommended_action: 'Configure rotation schedules or expiration for all secrets.',
+    apis: ['secrets:list'],
+    settings: {
+        secret_rotation_interval: {
+            name: 'Secret Rotation Interval',
+            description: 'Number of days after which secret age should trigger a warning',
+            regex: '^[1-9]{1}[0-9]{0,3}$',
+            default: '90'
+        }
+    },
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var rotationInterval = parseInt(settings.secret_rotation_interval || this.settings.secret_rotation_interval.default);
+
+        let projects = helpers.addSource(cache, source, ['projects', 'get', 'global']);
+
+        if (!projects || projects.err || !projects.data || !projects.data.length) {
+            helpers.addResult(results, 3,
+                'Unable to query for projects: ' + helpers.addError(projects), 'global', null, null, projects ? projects.err : null);
+            return callback(null, results, source);
+        }
+
+        var project = projects.data[0].name;
+
+        let secrets = helpers.addSource(cache, source, ['secrets', 'list', 'global']);
+
+        if (!secrets) return callback(null, results, source);
+
+        if (secrets.err || !secrets.data) {
+            helpers.addResult(results, 3, 'Unable to query secrets: ' + helpers.addError(secrets), 'global', null, null, secrets.err);
+            return callback(null, results, source);
+        }
+
+        if (!secrets.data.length) {
+            helpers.addResult(results, 0, 'No secrets found', 'global');
+            return callback(null, results, source);
+        }
+
+        secrets.data.forEach(secret => {
+            if (!secret.name) return; // skip if name missing
+            let name = secret.name.split('/').pop();
+            let resource = helpers.createResourceName('secrets', name, project, 'global');
+            let issues = [];
+
+            if (!secret.rotation && !secret.expireTime) {
+                issues.push('no rotation or expiration configured');
+            }
+
+            if (secret.createTime) {
+                let age = helpers.daysBetween(secret.createTime, new Date());
+                if (age > rotationInterval) {
+                    issues.push(`${age} days old`);
+                }
+            }
+
+            if (issues.length) {
+                helpers.addResult(results, 1, `Secret ${issues.join(' and ')}`, 'global', resource);
+            } else {
+                helpers.addResult(results, 0, 'Secret rotation configured', 'global', resource);
+            }
+        });
+
+        callback(null, results, source);
+    }
+};

--- a/plugins/google/secretmanager/secretRotation.spec.js
+++ b/plugins/google/secretmanager/secretRotation.spec.js
@@ -1,0 +1,96 @@
+var expect = require('chai').expect;
+var plugin = require('./secretRotation');
+
+const secrets = [
+    {
+        name: 'projects/testproj/secrets/secret1',
+        createTime: new Date().toISOString(),
+        rotation: { rotationPeriod: '604800s' }
+    },
+    {
+        name: 'projects/testproj/secrets/secret2',
+        createTime: '2021-01-01T00:00:00Z',
+        rotation: { rotationPeriod: '604800s' }
+    },
+    {
+        name: 'projects/testproj/secrets/secret3',
+        createTime: new Date().toISOString()
+    },
+    {
+        name: 'projects/testproj/secrets/secret4',
+        createTime: new Date().toISOString(),
+        expireTime: '2099-01-01T00:00:00Z'
+    }
+];
+
+const createCache = (list, err) => {
+    return {
+        secrets: {
+            list: {
+                'global': {
+                    data: list,
+                    err: err
+                }
+            }
+        },
+        projects: {
+            get: {
+                'global': {
+                    data: [ { name: 'testproj' } ]
+                }
+            }
+        }
+    };
+};
+
+describe('secretRotation', function() {
+    describe('run', function() {
+        it('should give UNKNOWN if unable to query secrets', function(done) {
+            const cache = createCache([], { message: 'error' });
+            plugin.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(3);
+                done();
+            });
+        });
+
+        it('should pass if no secrets found', function(done) {
+            const cache = createCache([], null);
+            plugin.run(cache, {}, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(0);
+                done();
+            });
+        });
+
+        it('should warn if secret lacks rotation or expiration', function(done) {
+            const cache = createCache([secrets[2]], null);
+            plugin.run(cache, { secret_rotation_interval: 30 }, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(1);
+                expect(results[0].message).to.include('no rotation');
+                done();
+            });
+        });
+
+        it('should warn if secret is older than threshold', function(done) {
+            const cache = createCache([secrets[1]], null);
+            plugin.run(cache, { secret_rotation_interval: 30 }, (err, results) => {
+                expect(results.length).to.equal(1);
+                expect(results[0].status).to.equal(1);
+                expect(results[0].message).to.include('days old');
+                done();
+            });
+        });
+
+        it('should pass if secret has rotation or expiration and not old', function(done) {
+            const cache = createCache([secrets[0], secrets[3]], null);
+            plugin.run(cache, { secret_rotation_interval: 30 }, (err, results) => {
+                expect(results.length).to.equal(2);
+                expect(results[0].status).to.equal(0);
+                expect(results[1].status).to.equal(0);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add Google Secret Manager `secretRotation` plugin
- test coverage for plugin
- export the plugin

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410a5f9c2c832193462e948fb204ff