### PR TITLE
Add bucket public access prevention check

### DIFF
--- a/exports.js
+++ b/exports.js
@@ -1510,6 +1510,7 @@ module.exports = {
         'bucketAllUsersPolicy'          : require(__dirname + '/plugins/google/storage/bucketAllUsersPolicy.js'),
         'bucketRetentionPolicy'         : require(__dirname + '/plugins/google/storage/bucketRetentionPolicy.js'),
         'bucketUniformAccess'           : require(__dirname + '/plugins/google/storage/bucketUniformAccess.js'),
+        'bucketPublicAccessPrevention'  : require(__dirname + '/plugins/google/storage/bucketPublicAccessPrevention.js'),
         'bucketLifecycleConfigured'     : require(__dirname + '/plugins/google/storage/bucketLifecycleConfigured.js'),
         'bucketEncryption'              : require(__dirname + '/plugins/google/storage/bucketEncryption.js'),
         'bucketLabelsAdded'             : require(__dirname + '/plugins/google/storage/bucketLabelsAdded.js'),

--- a/plugins/google/storage/bucketPublicAccessPrevention.js
+++ b/plugins/google/storage/bucketPublicAccessPrevention.js
@@ -1,0 +1,59 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Bucket Public Access Prevention',
+    category: 'Storage',
+    domain: 'Storage',
+    severity: 'Medium',
+    description: 'Ensures public access prevention is enforced on storage buckets.',
+    more_info: 'Public access prevention blocks all public access to buckets and objects to avoid accidental exposure.',
+    link: 'https://cloud.google.com/storage/docs/public-access-prevention',
+    recommended_action: 'Ensure that public access prevention is enforced on storage buckets.',
+    apis: ['buckets:list'],
+    realtime_triggers: ['storage.buckets.update', 'storage.buckets.create', 'storage.buckets.delete'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        async.each(regions.buckets, function(region, rcb){
+            let buckets = helpers.addSource(
+                cache, source, ['buckets', 'list', region]);
+
+            if (!buckets) return rcb();
+
+            if (buckets.err || !buckets.data) {
+                helpers.addResult(results, 3, 'Unable to query storage buckets: ' + helpers.addError(buckets), region);
+                return rcb();
+            }
+
+            if (!buckets.data.length) {
+                helpers.addResult(results, 0, 'No storage buckets found', region);
+                return rcb();
+            }
+
+            var bucketFound = false;
+            buckets.data.forEach(bucket => {
+                if (bucket.name) {
+                    let resource = helpers.createResourceName('b', bucket.name);
+                    bucketFound = true;
+                    if (bucket.iamConfiguration && bucket.iamConfiguration.publicAccessPrevention === 'enforced') {
+                        helpers.addResult(results, 0, 'Bucket public access prevention enforced', region, resource);
+                    } else {
+                        helpers.addResult(results, 2, 'Bucket public access prevention not enforced', region, resource);
+                    }
+                }
+            });
+
+            if (!bucketFound) {
+                helpers.addResult(results, 0, 'No storage buckets found', region);
+            }
+
+            rcb();
+        }, function(){
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/storage/bucketPublicAccessPrevention.spec.js
+++ b/plugins/google/storage/bucketPublicAccessPrevention.spec.js
@@ -1,0 +1,92 @@
+var expect = require('chai').expect;
+var plugin = require('./bucketPublicAccessPrevention');
+
+const createCache = (err, data) => {
+    return {
+        buckets: {
+            list: {
+                'global': {
+                    err: err,
+                    data: data
+                }
+            }
+        }
+    }
+};
+
+describe('bucketPublicAccessPrevention', function () {
+    describe('run', function () {
+        it('should give unknown result if a bucket error is passed or no data is present', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query storage buckets');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+            const cache = createCache(
+                ['error'],
+                null,
+            );
+            plugin.run(cache, {}, callback);
+        });
+        it('should give passing result if no storage buckets found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No storage buckets found');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+            const cache = createCache(
+                null,
+                [],
+            );
+            plugin.run(cache, {}, callback);
+        });
+        it('should give passing result if public access prevention is enforced', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('Bucket public access prevention enforced');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+            const cache = createCache(
+                null,
+                [
+                    {
+                        id: "pape-bucket",
+                        name: "pape-bucket",
+                        iamConfiguration: {
+                          publicAccessPrevention: 'enforced'
+                        }
+                    }
+                ],
+            );
+            plugin.run(cache, {}, callback);
+        });
+        it('should give failing result if public access prevention is not enforced', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('Bucket public access prevention not enforced');
+                expect(results[0].region).to.equal('global');
+                done()
+            };
+            const cache = createCache(
+                null,
+                [
+                    {
+                        id: "pape-bucket2",
+                        name: "pape-bucket2",
+                        iamConfiguration: {
+                          publicAccessPrevention: 'unspecified'
+                        }
+                    }
+                ],
+            );
+            plugin.run(cache, {}, callback);
+        });
+    })
+});


### PR DESCRIPTION
## Summary
- add new plugin `bucketPublicAccessPrevention` for GCP Storage
- test coverage for the new check
- export the plugin via `exports.js`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410a5ed0f083218444caae8ba57442