### PR TITLE
Add Cloud Run public access plugin

### DIFF
--- a/exports.js
+++ b/exports.js
@@ -1609,6 +1609,7 @@ module.exports = {
         'functionAllUsersPolicy'        : require(__dirname + '/plugins/google/cloudfunctions/functionAllUsersPolicy.js'),
         'serverlessVPCAccess'           : require(__dirname + '/plugins/google/cloudfunctions/serverlessVPCAccess.js'),
         'cloudFunctionNetworkExposure'  : require(__dirname + '/plugins/google/cloudfunctions/cloudFunctionNetworkExposure.js'),
+        'cloudRunPublicAccess'          : require(__dirname + '/plugins/google/cloudrun/cloudRunPublicAccess.js'),
 
         'computeAllowedExternalIPs'     : require(__dirname + '/plugins/google/cloudresourcemanager/computeAllowedExternalIPs.js'),
         'disableAutomaticIAMGrants'     : require(__dirname + '/plugins/google/cloudresourcemanager/disableAutomaticIAMGrants.js'),

--- a/plugins/google/cloudrun/cloudRunPublicAccess.js
+++ b/plugins/google/cloudrun/cloudRunPublicAccess.js
@@ -1,0 +1,85 @@
+var async = require('async');
+var helpers = require('../../../helpers/google');
+
+module.exports = {
+    title: 'Cloud Run Public Access',
+    category: 'Cloud Run',
+    domain: 'Serverless',
+    severity: 'High',
+    description: 'Ensure Cloud Run services are not publicly invokable.',
+    more_info: 'Allowing unauthenticated invocations exposes Cloud Run services to anyone on the internet.',
+    link: 'https://cloud.google.com/run/docs/authenticating/service-to-service',
+    recommended_action: 'Require authentication for all Cloud Run services.',
+    apis: ['run:services', 'run:servicesgetIamPolicy'],
+    realtime_triggers: ['run.googleapis.com.Service.Create', 'run.googleapis.com.Service.Update', 'run.googleapis.com.Service.Delete'],
+
+    run: function(cache, settings, callback) {
+        var results = [];
+        var source = {};
+        var regions = helpers.regions();
+
+        var regionList = regions.regions || regions.all_regions || [];
+        if (!regionList.length) regionList = Object.keys(regions.zones || {});
+
+        async.each(regionList, function(region, rcb) {
+            var services = helpers.addSource(cache, source, ['run', 'services', region]);
+
+            if (!services) return rcb();
+
+            if (services.err || !services.data) {
+                helpers.addResult(results, 3,
+                    'Unable to query Cloud Run services: ' + helpers.addError(services), region, null, null, services.err);
+                return rcb();
+            }
+
+            if (!services.data.length) {
+                helpers.addResult(results, 0, 'No Cloud Run services found', region);
+                return rcb();
+            }
+
+            var policies = helpers.addSource(cache, source, ['run', 'servicesgetIamPolicy', region]);
+
+            if (!policies) return rcb();
+
+            if (policies.err || !policies.data) {
+                helpers.addResult(results, 3,
+                    'Unable to query Cloud Run service policies: ' + helpers.addError(policies), region, null, null, policies.err);
+                return rcb();
+            }
+
+            services.data.forEach(service => {
+                if (!service.metadata || !service.metadata.name) return;
+
+                let policy = policies.data.find(p => p.parent && p.parent.name === service.metadata.name);
+                let publicAccess = false;
+                if (policy && policy.bindings && policy.bindings.length) {
+                    policy.bindings.forEach(binding => {
+                        if (binding.members && binding.members.length) {
+                            binding.members.forEach(member => {
+                                if (member === 'allUsers' || member === 'allAuthenticatedUsers') {
+                                    publicAccess = true;
+                                }
+                            });
+                        }
+                    });
+                }
+
+                let nameParts = service.metadata.name.split('/');
+                let serviceName = nameParts[nameParts.length - 1];
+                let resource = helpers.createResourceName('services', serviceName, null, 'location', region);
+
+                if (publicAccess) {
+                    helpers.addResult(results, 2,
+                        'Cloud Run service allows unauthenticated invocations', region, resource);
+                } else {
+                    helpers.addResult(results, 0,
+                        'Cloud Run service requires authentication', region, resource);
+                }
+            });
+
+            rcb();
+        }, function() {
+            callback(null, results, source);
+        });
+    }
+};

--- a/plugins/google/cloudrun/cloudRunPublicAccess.spec.js
+++ b/plugins/google/cloudrun/cloudRunPublicAccess.spec.js
@@ -1,0 +1,105 @@
+var expect = require('chai').expect;
+var plugin = require('./cloudRunPublicAccess');
+
+const createCache = (policyErr, policies, serviceErr, services) => {
+    return {
+        run: {
+            services: {
+                'us-central1': {
+                    err: serviceErr,
+                    data: services
+                }
+            },
+            servicesgetIamPolicy: {
+                'us-central1': {
+                    err: policyErr,
+                    data: policies
+                }
+            }
+        }
+    };
+};
+
+const services = [
+    {
+        metadata: {
+            name: 'projects/test-proj/locations/us-central1/services/service-1'
+        }
+    },
+    {
+        metadata: {
+            name: 'projects/test-proj/locations/us-central1/services/service-2'
+        }
+    }
+];
+
+const policies = [
+    {
+        parent: { name: 'projects/test-proj/locations/us-central1/services/service-1' },
+        bindings: [ { role: 'roles/run.invoker', members: ['allUsers'] } ]
+    },
+    {
+        parent: { name: 'projects/test-proj/locations/us-central1/services/service-2' },
+        bindings: [ { role: 'roles/run.invoker', members: ['user:test@example.com'] } ]
+    }
+];
+
+describe('cloudRunPublicAccess', function () {
+    describe('run', function () {
+        it('should give unknown result if unable to query Cloud Run services', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(3);
+                expect(results[0].message).to.include('Unable to query Cloud Run services');
+                expect(results[0].region).to.equal('us-central1');
+                done();
+            };
+
+            const cache = createCache(null, [], {message: 'error'}, []);
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if no services are found', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('No Cloud Run services found');
+                expect(results[0].region).to.equal('us-central1');
+                done();
+            };
+
+            const cache = createCache(null, [], null, []);
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give failing result if service allows unauthenticated access', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(2);
+                expect(results[0].message).to.include('Cloud Run service allows unauthenticated invocations');
+                expect(results[0].region).to.equal('us-central1');
+                done();
+            };
+
+            const cache = createCache(null, [policies[0]], null, [services[0]]);
+
+            plugin.run(cache, {}, callback);
+        });
+
+        it('should give passing result if service requires authentication', function (done) {
+            const callback = (err, results) => {
+                expect(results.length).to.be.above(0);
+                expect(results[0].status).to.equal(0);
+                expect(results[0].message).to.include('Cloud Run service requires authentication');
+                expect(results[0].region).to.equal('us-central1');
+                done();
+            };
+
+            const cache = createCache(null, [policies[1]], null, [services[1]]);
+
+            plugin.run(cache, {}, callback);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add plugin to check if Cloud Run services allow unauthenticated access
- test coverage for the new plugin
- expose plugin in exports

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410a5e57308321b9c34e61aa27deba